### PR TITLE
fix: RSS ECOMM 2 27 Display all nav buttons

### DIFF
--- a/src/components/NavMain.module.scss
+++ b/src/components/NavMain.module.scss
@@ -2,7 +2,6 @@
   width: 100%;
   display: flex;
   justify-content: space-between;
-  padding: 0 20px;
   align-items: center;
   border-bottom: 2px solid #e5eeea;
   background-color: #ccd4d1;
@@ -14,7 +13,7 @@
   justify-content: space-between;
   align-items: center;
   list-style: none;
-  max-width: 800px;
+  max-width: 700px;
   width: 100%;
   height: 100%;
   padding: 0;
@@ -58,7 +57,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  max-width: 200px;
+  max-width: 400px;
   width: 100%;
   height: 100%;
 }

--- a/src/components/NavMain.ts
+++ b/src/components/NavMain.ts
@@ -47,7 +47,7 @@ export default class NavMain {
 
     const navBtnsContainer = div({ className: styles.navBtnsContainer });
     this.navBtnsContainer = navBtnsContainer;
-    this.renderLoggedOutNav();
+    this.renderNavButtons();
 
     menu.append(list, navBtnsContainer);
     this.menuElement = menu;
@@ -85,34 +85,17 @@ export default class NavMain {
     return btn;
   }
 
-  public renderLoggedInNav(): void {
+  public renderNavButtons(): void {
     this.navBtnsContainer.innerHTML = '';
 
+    const loginBtn = this.createNavBtn('Log In', styles.userIcon);
+    const signUpBtn = this.createNavBtn('Sign Up', styles.signUpIcon);
     const profileBtn = this.createNavBtn('My Profile', styles.userIcon);
     const logoutBtn = this.createNavBtn('Log Out', styles.logoutIcon);
 
     profileBtn.addEventListener('click', () => {
       Router.go('/profile', { addToHistory: true });
     });
-
-    logoutBtn.addEventListener('click', () => {
-      localStorage.removeItem('anonymousToken');
-      localStorage.removeItem('passwordToken');
-
-      this.renderLoggedOutNav();
-
-      this.service.updateClient(anonymousClient);
-      this.service.getAnonymousToken();
-    });
-
-    this.navBtnsContainer.append(profileBtn, logoutBtn);
-  }
-
-  public renderLoggedOutNav(): void {
-    this.navBtnsContainer.innerHTML = '';
-
-    const loginBtn = this.createNavBtn('Log In', styles.userIcon);
-    const signUpBtn = this.createNavBtn('Sign Up', styles.signUpIcon);
 
     loginBtn.addEventListener('click', () => {
       Router.go('/login', { addToHistory: true });
@@ -121,7 +104,14 @@ export default class NavMain {
     signUpBtn.addEventListener('click', () => {
       Router.go('/registration', { addToHistory: true });
     });
+    logoutBtn.addEventListener('click', () => {
+      localStorage.removeItem('anonymousToken');
+      localStorage.removeItem('passwordToken');
 
-    this.navBtnsContainer.append(loginBtn, signUpBtn);
+      this.service.updateClient(anonymousClient);
+      this.service.getAnonymousToken();
+    });
+
+    this.navBtnsContainer.append(loginBtn, signUpBtn, profileBtn, logoutBtn);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,6 @@ class App {
       if (client) {
         localStorage.setItem('passwordToken', JSON.stringify(anonCacheClass.get()));
         this.service = client;
-        this.layout.renderLoggedInNav();
       }
     });
 
@@ -42,12 +41,9 @@ class App {
     // Render profile and logout buttons if logged in
     const user = JSON.parse(localStorage.getItem('passwordToken') ?? 'null');
     if (user) {
-      this.layout.renderLoggedInNav();
       this.layout.navMain.logoutBtn.addEventListener('click', () => {
         localStorage.removeItem('anonymousToken');
         localStorage.removeItem('passwordToken');
-
-        this.layout.renderLoggedOutNav();
 
         this.service.updateClient(anonymousClient);
         this.service.getAnonymousToken();

--- a/src/pages/Layout.ts
+++ b/src/pages/Layout.ts
@@ -50,13 +50,6 @@ export class Layout {
       document.body.appendChild(layout);
     }
   }
-
-  public renderLoggedInNav(): void {
-    this.navMain.renderLoggedInNav();
-  }
-  public renderLoggedOutNav(): void {
-    this.navMain.renderLoggedOutNav();
-  }
 }
 
 // export const renderLayout = (): void => {


### PR DESCRIPTION
### [RSS-ECOMM-2_27: Display all nav buttons](https://github.com/egorokunevich/eCommerce-App/issues/74)📝

#### Description 🗂️

Nav currently adapts to state of user (logged in or not) and draw login/signUp or profile/logout. It should display all the buttons. But redirect to Home Page from LoginPage / SignUp Page if logged in. Redirect to Home Page from Profile Page if logged out.

#### Acceptance Criteria 🎯

- All the buttons in nav are displayed.  
- Routing implemented depending wether user is logged in.  
  

## Issue ticket number 🎫

#74   

## Change type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Chore

## Checklist ✅

- [x] I have tested the changes locally
- [x] I have reviewed the code for readability and maintainability
- [ ] I have updated the documentation, if necessary
- [x] I have considered the impact of these changes on other parts of the system
- [x] I have assigned reviewers to this pull request

## Score

0 / 200

## Screenshots 📷

- [x] Screenshots
![image](https://github.com/egorokunevich/eCommerce-App/assets/84414222/5ab12057-c06e-48b1-823e-9d3c007c29c0)


