### PR TITLE
fix: RSS ECOMM Background size of 404 page

### DIFF
--- a/src/pages/NotFoundPage.module.scss
+++ b/src/pages/NotFoundPage.module.scss
@@ -12,7 +12,6 @@
     display: flex;
     align-items: center;
     flex-direction: column;
-    background-size: 70%;
   }
 }
 .info-container,


### PR DESCRIPTION
### RSS-ECOMM-3_00: Fix background size of 404 pagee  📝

#### Description 🗂️

Fixed background image responsiveness


## Change type

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Chore

## Checklist ✅

- [x] I have tested the changes locally
- [x] I have reviewed the code for readability and maintainability
- [ ] I have updated the documentation, if necessary
- [x] I have considered the impact of these changes on other parts of the system
- [x] I have assigned reviewers to this pull request

## Score

0 / 200

## Screenshots 📷

- [x] Screenshots
![image](https://github.com/egorokunevich/eCommerce-App/assets/84414222/ad66bef5-cdec-4166-8d0b-96f85f2f4247)
![image](https://github.com/egorokunevich/eCommerce-App/assets/84414222/ddae1657-5266-440b-a31f-ea6fab69cdf4)





