### PR TITLE
feat: change displaying product prices

### DIFF
--- a/src/components/ProductCard/ProductCard.ts
+++ b/src/components/ProductCard/ProductCard.ts
@@ -61,12 +61,9 @@ export class ProductCard {
   private getProductPriceElement(product: ProductProjection): HTMLElement | null {
     if (product.masterVariant.prices) {
       const priceData = product.masterVariant.prices[0];
-
       const baseData = priceData.value;
 
-      const basePrice = span({ className: styles.priceValue, txt: this.countPrice(baseData).toString() });
-
-      const currency = span({ className: styles.priceValue, txt: priceData.value.currencyCode });
+      const basePrice = span({ className: styles.priceValue, txt: this.formatPrice(baseData) });
 
       const finalPrice = div({ className: styles.price });
 
@@ -74,20 +71,24 @@ export class ProductCard {
       if (this.checkForDiscount(product) && priceData.discounted) {
         const discountedPrice = span({ className: styles.priceValue });
         const discountedData = priceData.discounted?.value;
-        discountedPrice.innerText = this.countPrice(discountedData).toString();
+        discountedPrice.innerText = this.formatPrice(discountedData);
         discountedPrice.classList.add(styles.discount);
         basePrice.classList.add(styles.crossed);
         finalPrice.classList.add(styles.withDiscount);
         finalPrice.append(discountedPrice);
       }
-      finalPrice.append(currency);
       return finalPrice;
     }
     return null;
   }
 
-  private countPrice(price: TypedMoney): number {
-    return price.centAmount / 10 ** price.fractionDigits; // Divide by 100 cents
+  private formatPrice(price: TypedMoney): string {
+    const value = price.centAmount / 10 ** price.fractionDigits;
+    return value.toLocaleString(undefined, {
+      style: 'currency',
+      currency: price.currencyCode,
+      minimumFractionDigits: 2,
+    });
   }
 
   private checkForDiscount(product: ProductProjection): boolean {


### PR DESCRIPTION
### [Issue RSS-ECOMM-3_11: Display Product Price and Sale Price (15 points)](https://github.com/users/egorokunevich/projects/5/views/1?pane=issue&itemId=63485100)📝

#### Description 🗂️

The application should fetch and display the price 💲 for each product from the chosen API on the Detailed Product page. If the product is on sale, both the original price and the sale price should be displayed. The sale price should be clearly distinguished as the current price of the product.

#### Acceptance Criteria 🎯

<!-- # Example: -->

* The application successfully fetches and displays the price for each product from the chosen API.
* If the product is on sale, both the original price and the sale price are displayed. The sale price is clearly distinguished as the current price of the product.

## Issue ticket number 🎫

#93 

## Change type

- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Chore

## Checklist ✅

- [x] I have tested the changes locally
- [x] I have reviewed the code for readability and maintainability
- [ ] I have updated the documentation, if necessary
- [x] I have considered the impact of these changes on other parts of the system
- [x] I have assigned reviewers to this pull request

## Score

15/370

## Screenshots 📷

![image](https://github.com/egorokunevich/eCommerce-App/assets/124787126/e8a7c170-4a77-49c1-b880-c0293bf218c6)
![image](https://github.com/egorokunevich/eCommerce-App/assets/124787126/46393a55-ad32-48ff-81cb-dd0f98ad957f)

![image](https://github.com/egorokunevich/eCommerce-App/assets/124787126/bbc6f75c-6b68-4375-b5b9-35f27137b2da)
