### PR TITLE
feat: RSS-ECOMM-3_18: add address default

### DIFF
--- a/src/pages/RegistrationPage.ts
+++ b/src/pages/RegistrationPage.ts
@@ -210,7 +210,7 @@ export default class RegistrationPage {
     return nodeInput;
   }
 
-  private createDefaultSwitchBtn(name: string): HTMLElement {
+  public createDefaultSwitchBtn(name: string): HTMLElement {
     const nodeInput = setAttributes(input({ className: styleSwitch.switchInput }), { type: 'type', text: 'checkbox' });
     const node = div(
       {},

--- a/src/pages/UserProfile/add-new-address.ts
+++ b/src/pages/UserProfile/add-new-address.ts
@@ -1,0 +1,186 @@
+import type { Customer, MyCustomerUpdateAction } from '@commercetools/platform-sdk';
+import { button, div, form } from '@control.ts/min';
+
+import { ToastColors, showToastMessage } from '@components/Toast';
+import RegistrationPage from '@pages/RegistrationPage';
+import clientService from '@services/ClientService';
+import { isRegistrationActive, validationText } from '@utils/RegistrationValidationsData';
+
+/* eslint-disable import/no-cycle */
+
+import { createInformationUsers } from './create-data-users';
+import styles from './styles.module.scss';
+
+interface UserInput {
+  streetName: string;
+  streetNumber: string;
+  city: string;
+  country: string;
+  postalCode: string;
+}
+
+export class AddNewAddress {
+  private registrationPageClass: RegistrationPage = new RegistrationPage();
+
+  private defaultShipping: number | undefined = undefined;
+  private defaultBilling: number | undefined = undefined;
+
+  private inputStreetName: null | HTMLElement = null;
+  private inputStreetNumber: null | HTMLElement = null;
+  private inputCity: null | HTMLElement = null;
+  private inputCountry: null | HTMLElement = null;
+  private inputPostalCode: null | HTMLElement = null;
+
+  private async getDataFromServer(): Promise<Customer> {
+    const data = await clientService.apiRoot.me().get().execute();
+    return data.body;
+  }
+
+  public async addNewAddressContainer(): Promise<HTMLElement> {
+    const node = form({}, this.createInputs(), this.createDefaultBtn(), await this.createBtnToAddNewAddress());
+    return node;
+  }
+
+  private createInputs(): HTMLElement {
+    // const data = await this.getDataFromServer();
+    const node = div({});
+
+    const labelStreetName = this.registrationPageClass.createFormLabel('streetName', validationText.streetNameBilling);
+    this.inputStreetName = this.registrationPageClass.inputTag;
+
+    const labelStreetNumber = this.registrationPageClass.createFormLabel(
+      'streetNumber',
+      validationText.streetNumberBilling,
+    );
+    this.inputStreetNumber = this.registrationPageClass.inputTag;
+
+    const labelCity = this.registrationPageClass.createFormLabel('city', validationText.cityBilling);
+    this.inputCity = this.registrationPageClass.inputTag;
+
+    const labelCountry = this.registrationPageClass.createFormLabel('country', validationText.countryBilling);
+    this.inputCountry = this.registrationPageClass.inputTag;
+
+    const labelPostalCode = this.registrationPageClass.createFormLabel('postalCode', validationText.postalCodeBilling);
+    this.inputPostalCode = this.registrationPageClass.inputTag;
+
+    node.append(labelStreetName, labelStreetNumber, labelCity, labelCountry, labelPostalCode);
+
+    return node;
+  }
+
+  private async createBtnToAddNewAddress(): Promise<HTMLButtonElement> {
+    const { validationMessages } = this.registrationPageClass;
+    const btn = button({ className: styles.userInfoBtn, txt: 'Save New Address' });
+
+    btn.addEventListener('click', async (ev) => {
+      ev.preventDefault();
+      const inputsValue = this.checkInputsValue();
+      if (inputsValue && isRegistrationActive(validationMessages) && this.isInputsValueEmpty()) {
+        await this.addMyCustomerAddress(inputsValue);
+
+        showToastMessage('Your new Address was add', ToastColors.Green);
+        const addressLayout = document.querySelector(`.${styles.usersInformationContainer}`);
+        if (addressLayout) {
+          addressLayout.innerHTML = '';
+          addressLayout.append(await createInformationUsers.createProfileAddresses());
+        }
+      } else {
+        showToastMessage('Write all Fields', ToastColors.Red);
+      }
+    });
+    return btn;
+  }
+
+  private createDefaultBtn(): HTMLElement {
+    const defaultShippingBtn = this.registrationPageClass.createDefaultSwitchBtn('Shipping');
+    const defaultBillingBtn = this.registrationPageClass.createDefaultSwitchBtn('Billing');
+
+    defaultShippingBtn.addEventListener('click', () => {
+      this.defaultShipping = this.defaultShipping === undefined ? 0 : undefined;
+    });
+
+    defaultBillingBtn.addEventListener('click', () => {
+      this.defaultBilling = this.defaultBilling === undefined ? 1 : undefined;
+    });
+
+    const node = div({}, defaultBillingBtn, defaultShippingBtn);
+    return node;
+  }
+
+  public checkInputsValue(): UserInput | undefined {
+    if (
+      this.inputStreetName instanceof HTMLInputElement &&
+      this.inputStreetNumber instanceof HTMLInputElement &&
+      this.inputCity instanceof HTMLInputElement &&
+      this.inputCountry instanceof HTMLInputElement &&
+      this.inputPostalCode instanceof HTMLInputElement
+    ) {
+      return {
+        streetName: this.inputStreetName.value,
+        streetNumber: this.inputStreetNumber.value,
+        city: this.inputCity.value,
+        country: this.inputCountry.value,
+        postalCode: this.inputPostalCode.value,
+      };
+    }
+    return undefined;
+  }
+
+  private isInputsValueEmpty(): boolean {
+    const inputsValue = this.checkInputsValue();
+
+    return inputsValue ? Object.values(inputsValue).every((value) => value !== '') : false;
+  }
+
+  private async addMyCustomerAddress(newAddress: UserInput): Promise<Customer> {
+    const actions: MyCustomerUpdateAction[] = [
+      {
+        action: 'addAddress',
+        address: newAddress,
+      },
+    ];
+
+    const response = await clientService.apiRoot
+      .me()
+      .post({
+        body: {
+          version: (await this.getDataFromServer()).version,
+          actions,
+        },
+      })
+      .execute();
+    this.makeDefaultAddress(response.body);
+    return response.body;
+    // return updateActions.body;
+  }
+
+  private async makeDefaultAddress(response: Customer): Promise<void> {
+    const addressId = response.addresses[response.addresses.length - 1].id;
+
+    const updateActions: MyCustomerUpdateAction[] = [];
+
+    if (typeof this.defaultBilling === 'number') {
+      updateActions.push({
+        action: 'setDefaultBillingAddress',
+        addressId,
+      });
+    }
+    if (typeof this.defaultShipping === 'number') {
+      updateActions.push({
+        action: 'setDefaultShippingAddress',
+        addressId,
+      });
+    }
+    if (updateActions.length >= 1) {
+      await clientService.apiRoot
+        .me()
+        .post({
+          body: {
+            version: (await this.getDataFromServer()).version,
+            actions: updateActions,
+          },
+        })
+        .execute();
+    }
+  }
+}

--- a/src/pages/UserProfile/create-data-users.ts
+++ b/src/pages/UserProfile/create-data-users.ts
@@ -2,14 +2,18 @@ import type { Customer } from '@commercetools/platform-sdk';
 import { article, button, div, h3, input, p, span } from '@control.ts/min';
 
 import { ToastColors, showToastMessage } from '@components/Toast';
-import RegistrationPage from '@pages/RegistrationPage';
 import clientService from '@services/ClientService';
 import { validationText } from '@utils/RegistrationValidationsData';
 
+/* eslint-disable import/no-cycle */
+import { AddNewAddress } from './add-new-address';
 import styles from './styles.module.scss';
 
 export class CreateInformationUsers {
   private showAllAddressesStatus = false;
+  private showNewAddressesStatus = false;
+
+  private addNewAddress: AddNewAddress = new AddNewAddress();
   private allAddressesContainer: null | HTMLDivElement = null;
   private defaultBillingAddressId: string | undefined = undefined;
   private defaultShippingAddressId: string | undefined = undefined;
@@ -35,14 +39,18 @@ export class CreateInformationUsers {
     return node;
   }
 
-  private createAddressButtonsContainer(showAllButton: HTMLButtonElement): HTMLDivElement {
+  private async createAddressButtonsContainer(showAllButton: HTMLButtonElement): Promise<HTMLDivElement> {
     const container = div({ className: styles.addressButtonsContainer });
     const addAddressButton = button({ className: styles.userInfoBtn, txt: 'Add Address' });
-
+    const newAddress = await this.addNewAddress.addNewAddressContainer();
     addAddressButton.addEventListener('click', () => {
-      const registrationPage = new RegistrationPage();
-      const addressForm = registrationPage.createFormAddress();
-      container.append(addressForm);
+      // her change info for add address
+      if (this.showNewAddressesStatus) {
+        newAddress.remove();
+      } else {
+        container.append(newAddress);
+      }
+      this.showNewAddressesStatus = !this.showNewAddressesStatus;
     });
 
     container.append(showAllButton, addAddressButton);
@@ -65,7 +73,7 @@ export class CreateInformationUsers {
     }
     this.allAddressesContainer = div({ className: styles.allAddressesContainer });
     const buttonShowAllAddresses = this.buttonShowAllAddresses(this.allAddressesContainer);
-    const addressButtonsContainer = this.createAddressButtonsContainer(buttonShowAllAddresses);
+    const addressButtonsContainer = await this.createAddressButtonsContainer(buttonShowAllAddresses);
     node.append(addressButtonsContainer, this.allAddressesContainer);
     return node;
   }
@@ -274,3 +282,5 @@ export class CreateInformationUsers {
     }
   }
 }
+
+export const createInformationUsers = new CreateInformationUsers();

--- a/src/pages/UserProfile/create-user-pages.ts
+++ b/src/pages/UserProfile/create-user-pages.ts
@@ -6,7 +6,7 @@ import { CreateInformationUsers } from './create-data-users';
 import styles from './styles.module.scss';
 
 export class UserProfile {
-  private profileInformationContainer: null | HTMLDivElement = null;
+  public profileInformationContainer: null | HTMLDivElement = null;
   private btnUserStatus = false;
 
   public createUserPage(): HTMLDivElement {
@@ -93,3 +93,5 @@ export class UserProfile {
     return btn;
   }
 }
+
+export const userProfile = new UserProfile();


### PR DESCRIPTION
### [ Issue RSS-ECOMM-3_18: Manage Addresses 🏡 in User Profile Page with commercetools API](https://github.com/users/egorokunevich/projects/5/views/1?pane=issue&itemId=63485190)📝

<!-- # Example: -->
<!-- [RSS-ECOMM-1_13: Install and configure Jest or Vitest] (https://github.com/egorokunevich/eCommerce-App/issues/17) -->

### 📋 Description
Users should have the capability to manage their addresses within the application. This feature increases user autonomy and ensures they can maintain their address details up-to-date using the commercetools API. Users should also be able to set default billing and shipping addresses.

###  🔨 Implementation Details
Address Management Option: Provide a distinct option for users to access address management within their user profile.
Adding New Addresses: Allow users to add new addresses by entering all required address details (e.g., name, street, city, postcode, country).
Deleting Existing Addresses: Enable users to remove existing addresses.
Updating Address Details: Permit users to update existing address details with valid information.
Set Default Billing and Shipping Addresses: Allow users to choose their default billing and shipping addresses from the list of existing addresses.
Form Validation: Ensure the provided address details meet the necessary criteria (non-empty fields, valid format).
Backend Integration: Implement address management by integrating with the commercetools API for customers and addresses, following the appropriate API guidelines.

###  🎨 Visual Implementation Ideas
Addresses List: Display a list or card view of the user's existing addresses, with information organized neatly and clearly.
Add Address Button: Add a visible "Add Address" button above or below the addresses list, making it easy to create a new address.
Edit and Delete Icons: Place edit 📝 and delete ❌ icons next to each address, allowing users to quickly update or remove addresses as needed.
Default Billing and Shipping Selection: Include checkboxes or radio buttons next to each address, allowing users to select default billing and shipping addresses.
Address Entry Modal: Use a modal or dropdown to show address entry fields, ensuring a clean interface that saves space.
✅ Acceptance Criteria
Users can manage their addresses within the User Profile page using commercetools API, including adding new addresses, deleting existing ones, and updating address details.
Users can set their default billing and shipping addresses.
The system validates input address details according to the necessary criteria.
The application properly integrates with the commercetools API for address management purposes.

## Issue ticket number 🎫

<!-- #1 RSS-ECOMM-1_02: Set up folder structure -->

## Change type

- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Chore

## Checklist ✅

- [x] I have tested the changes locally
- [x] I have reviewed the code for readability and maintainability
- [x] I have updated the documentation, if necessary
- [x] I have considered the impact of these changes on other parts of the system
- [x] I have assigned reviewers to this pull request

## Score

<!-- 15/15 -->

## Screenshots 📷

- [ ] Screenshots
<!-- [Add screenshots or gifs to visually demonstrate the changes, if applicable if it's need] -->
